### PR TITLE
RefreshTokens, DB-compatibility

### DIFF
--- a/MoviesOnDemandBackend/Controllers/UsersController.cs
+++ b/MoviesOnDemandBackend/Controllers/UsersController.cs
@@ -46,4 +46,11 @@ public class UsersController : ControllerBase
         var user = _usersService.DislikeMovie(id);
         return Ok(user);
     }
+
+    [HttpPost("RefreshToken")]
+    public ActionResult<string> RefreshToken()
+    {
+        var token = _usersService.RefreshToken();
+        return Ok(token);
+    }
 }

--- a/MoviesOnDemandBackend/Controllers/UsersController.cs
+++ b/MoviesOnDemandBackend/Controllers/UsersController.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using MoviesOnDemandBackend.Entities;
 using MoviesOnDemandBackend.Models;
 using MoviesOnDemandBackend.Services;
 
@@ -18,11 +17,11 @@ public class UsersController : ControllerBase
     }
     
     [HttpPost("Register")]
-    public ActionResult<User> Register([FromBody] UserRegisterDto userRegisterDto)
+    public ActionResult<int> Register([FromBody] UserRegisterDto userRegisterDto)
     {
-        var user = _usersService.Register(userRegisterDto);
+        var userId = _usersService.Register(userRegisterDto);
 
-        return Ok(user);
+        return Ok(userId);
     }
 
     [HttpPost("Login")]
@@ -33,24 +32,26 @@ public class UsersController : ControllerBase
         return Ok(token);
     }
 
-    [HttpPost("LikeMovie/{id}"), Authorize(Roles = "user")]
-    public ActionResult<UserDto> LikeMovie([FromRoute] int id)
+    [HttpPost("{userId}/LikeMovie/{movieId}"), Authorize(Roles = "user")]
+    public ActionResult<string> LikeMovie([FromRoute] int userId, [FromRoute] int movieId)
     {
-        var user = _usersService.LikeMovie(id);
-        return Ok(user);
+        _usersService.LikeMovie(userId, movieId);
+        
+        return Ok("Movie successfully liked");
     }
 
-    [HttpDelete("DislikeMovie/{id}"), Authorize(Roles = "user")]
-    public ActionResult<UserDto> DislikeMovie([FromRoute] int id)
+    [HttpDelete("{userId}/DislikeMovie/{movieId}"), Authorize(Roles = "user")]
+    public ActionResult<string> DislikeMovie([FromRoute] int userId, [FromRoute] int movieId)
     {
-        var user = _usersService.DislikeMovie(id);
-        return Ok(user);
+        _usersService.DislikeMovie(userId, movieId);
+        
+        return Ok("Movie disliked");
     }
 
-    [HttpPost("RefreshToken")]
-    public ActionResult<string> RefreshToken()
+    [HttpPost("{id}/RefreshToken")]
+    public ActionResult<string> RefreshToken([FromRoute] int id)
     {
-        var token = _usersService.RefreshToken();
+        var token = _usersService.RefreshToken(id);
         return Ok(token);
     }
 }

--- a/MoviesOnDemandBackend/Entities/Configurations/UsersConfiguration.cs
+++ b/MoviesOnDemandBackend/Entities/Configurations/UsersConfiguration.cs
@@ -34,5 +34,10 @@ public class UsersConfiguration : IEntityTypeConfiguration<User>
             .Property(u => u.Role)
             .HasDefaultValue("user")
             .IsRequired();
+
+        builder
+            .Property(u => u.AccountCreated)
+            .HasColumnType("Date")
+            .IsRequired();
     }
 }

--- a/MoviesOnDemandBackend/Entities/MoviesOnDemandDbContext.cs
+++ b/MoviesOnDemandBackend/Entities/MoviesOnDemandDbContext.cs
@@ -12,6 +12,7 @@ public class MoviesOnDemandDbContext : DbContext
     
     public DbSet<Movie> Movies { get; set; }
     public DbSet<User> Users { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/MoviesOnDemandBackend/Entities/RefreshToken.cs
+++ b/MoviesOnDemandBackend/Entities/RefreshToken.cs
@@ -1,0 +1,11 @@
+namespace MoviesOnDemandBackend.Entities;
+
+public class RefreshToken
+{
+    public int Id { get; set; }
+    public string Token { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Expires { get; set; }
+    public int UserId { get; set; }
+    public User User { get; set; }
+}

--- a/MoviesOnDemandBackend/Entities/User.cs
+++ b/MoviesOnDemandBackend/Entities/User.cs
@@ -8,8 +8,7 @@ public class User
     public byte[] PasswordHash { get; set; }
     public byte[] PasswordSalt { get; set; }
     public string Role { get; set; }
+    public DateTime AccountCreated { get; set; }
     public ICollection<Movie> FavoriteMovies { get; set; }
-    public string RefreshToken { get; set; }
-    public DateTime RefreshTokenCreated { get; set; }
-    public DateTime RefreshTokenExpires { get; set; }
+    public RefreshToken RefreshToken { get; set; }
 }

--- a/MoviesOnDemandBackend/Entities/User.cs
+++ b/MoviesOnDemandBackend/Entities/User.cs
@@ -9,4 +9,7 @@ public class User
     public byte[] PasswordSalt { get; set; }
     public string Role { get; set; }
     public ICollection<Movie> FavoriteMovies { get; set; }
+    public string RefreshToken { get; set; }
+    public DateTime RefreshTokenCreated { get; set; }
+    public DateTime RefreshTokenExpires { get; set; }
 }

--- a/MoviesOnDemandBackend/Exceptions/UnauthorizedException.cs
+++ b/MoviesOnDemandBackend/Exceptions/UnauthorizedException.cs
@@ -1,0 +1,9 @@
+namespace MoviesOnDemandBackend.Exceptions;
+
+public class UnauthorizedException : Exception
+{
+    public UnauthorizedException(string message) : base(message)
+    {
+        
+    }
+}

--- a/MoviesOnDemandBackend/Mapping/UserMappingProfile.cs
+++ b/MoviesOnDemandBackend/Mapping/UserMappingProfile.cs
@@ -8,6 +8,6 @@ public class UserMappingProfile : Profile
 {
     public UserMappingProfile()
     {
-        CreateMap<User, UserDto>();
+        CreateMap<UserRegisterDto, User>();
     }
 }

--- a/MoviesOnDemandBackend/Middleware/ErrorHandlingMiddleware.cs
+++ b/MoviesOnDemandBackend/Middleware/ErrorHandlingMiddleware.cs
@@ -32,8 +32,8 @@ public class ErrorHandlingMiddleware : IMiddleware
         
         catch (Exception e)
         {
-            //context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-            //await context.Response.WriteAsync("Something went wrong.");
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            await context.Response.WriteAsync("Something went wrong.");
             Console.Write(e);
         }
     }

--- a/MoviesOnDemandBackend/Middleware/ErrorHandlingMiddleware.cs
+++ b/MoviesOnDemandBackend/Middleware/ErrorHandlingMiddleware.cs
@@ -23,6 +23,12 @@ public class ErrorHandlingMiddleware : IMiddleware
             context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
             await context.Response.WriteAsync(badRequest.Message);
         }
+
+        catch (UnauthorizedException unauthorizedException)
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+            await context.Response.WriteAsync(unauthorizedException.Message);
+        }
         
         catch (Exception e)
         {

--- a/MoviesOnDemandBackend/Migrations/20230223195302_RefreshTokens.Designer.cs
+++ b/MoviesOnDemandBackend/Migrations/20230223195302_RefreshTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MoviesOnDemandBackend.Entities;
 
@@ -11,9 +12,11 @@ using MoviesOnDemandBackend.Entities;
 namespace MoviesOnDemandBackend.Migrations
 {
     [DbContext(typeof(MoviesOnDemandDbContext))]
-    partial class MoviesOnDemandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230223195302_RefreshTokens")]
+    partial class RefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -219,7 +222,7 @@ namespace MoviesOnDemandBackend.Migrations
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("AccountCreated")
-                        .HasColumnType("Date");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Email")
                         .IsRequired()

--- a/MoviesOnDemandBackend/Migrations/20230223195302_RefreshTokens.cs
+++ b/MoviesOnDemandBackend/Migrations/20230223195302_RefreshTokens.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoviesOnDemandBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AccountCreated",
+                table: "Users",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Token = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Expires = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UserId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "AccountCreated",
+                table: "Users");
+        }
+    }
+}

--- a/MoviesOnDemandBackend/Migrations/20230223201623_DateColumnUpdate.Designer.cs
+++ b/MoviesOnDemandBackend/Migrations/20230223201623_DateColumnUpdate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MoviesOnDemandBackend.Entities;
 
@@ -11,9 +12,11 @@ using MoviesOnDemandBackend.Entities;
 namespace MoviesOnDemandBackend.Migrations
 {
     [DbContext(typeof(MoviesOnDemandDbContext))]
-    partial class MoviesOnDemandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230223201623_DateColumnUpdate")]
+    partial class DateColumnUpdate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MoviesOnDemandBackend/Migrations/20230223201623_DateColumnUpdate.cs
+++ b/MoviesOnDemandBackend/Migrations/20230223201623_DateColumnUpdate.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoviesOnDemandBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class DateColumnUpdate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "AccountCreated",
+                table: "Users",
+                type: "Date",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "AccountCreated",
+                table: "Users",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "Date");
+        }
+    }
+}

--- a/MoviesOnDemandBackend/Models/RefreshToken.cs
+++ b/MoviesOnDemandBackend/Models/RefreshToken.cs
@@ -1,8 +1,0 @@
-namespace MoviesOnDemandBackend.Models;
-
-public class RefreshToken
-{
-    public string Token { get; set; }
-    public DateTime DateCreated { get; set; }
-    public DateTime DateExpires { get; set; }
-}

--- a/MoviesOnDemandBackend/Models/RefreshToken.cs
+++ b/MoviesOnDemandBackend/Models/RefreshToken.cs
@@ -1,0 +1,8 @@
+namespace MoviesOnDemandBackend.Models;
+
+public class RefreshToken
+{
+    public string Token { get; set; }
+    public DateTime DateCreated { get; set; }
+    public DateTime DateExpires { get; set; }
+}

--- a/MoviesOnDemandBackend/Models/UserDto.cs
+++ b/MoviesOnDemandBackend/Models/UserDto.cs
@@ -5,5 +5,10 @@ public class UserDto
     public int Id { get; set; }
     public string Email { get; set; }
     public string Username { get; set; }
+    public string Role { get; set; }
+    public DateTime AccountCreated { get; set; }
     public List<MovieDto> FavoriteMovies { get; set; }
+    public string RefreshToken { get; set; }
+    public DateTime RefreshTokenCreated { get; set; }
+    public DateTime RefreshTokenExpires { get; set; }
 }

--- a/MoviesOnDemandBackend/Models/UserLoginDto.cs
+++ b/MoviesOnDemandBackend/Models/UserLoginDto.cs
@@ -2,6 +2,6 @@ namespace MoviesOnDemandBackend.Models;
 
 public class UserLoginDto
 {
-    public string Username { get; set; }
+    public string Email { get; set; }
     public string Password { get; set; }
 }

--- a/MoviesOnDemandBackend/Program.cs
+++ b/MoviesOnDemandBackend/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddDbContext<MoviesOnDemandDbContext>(options =>
 {
     options.UseSqlServer(builder.Configuration.GetConnectionString("MoviesOnDemandDB"));
 });
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ErrorHandlingMiddleware>();
 builder.Services.AddScoped<IMoviesService, MoviesService>();
 builder.Services.AddScoped<IUsersService, UsersService>();


### PR DESCRIPTION
/Users/{userId}/RefreshToken endpoint is intended to be invoked every 15 minutes to generate a new JWT and refresh token. /Api/Users/{userId}/LikeMovie/{movieId} endpoint lets user add a movie to their favorite movies collection and /Api/Users/{userId}/DislikeMovie/{movieId} removes movie of specified id from user favorite movies collection. RefreshToken endpoint now requiries user Id to refresh token for specified user and thus route changed to /Api/Users/{userId}/RefreshToken. Added RefreshToken entity. User now logs in with e-mail instead of username. Added AccountCreated property to User entity to track when user created account, changed its format to yyyy-mm-dd in UsersConfiguration.cs. Return 500 internal server error if unspecified exception is caught.