### PR TITLE
Changing user data and deleting account. Security improvements. Authentication Service update

### DIFF
--- a/MoviesOnDemandBackend/Controllers/AccountController.cs
+++ b/MoviesOnDemandBackend/Controllers/AccountController.cs
@@ -32,4 +32,36 @@ public class AccountController : ControllerBase
 
         return Ok(movieDtos);
     }
+    
+    [HttpPatch("ChangeEmail")]
+    public ActionResult<string> ChangeEmail([FromBody] ChangeEmailDto changeEmailDto)
+    {
+        var token = _accountService.ChangeEmail(changeEmailDto);
+
+        return Ok(token);
+    }
+    
+    [HttpPatch("ChangeUsername")]
+    public ActionResult<string> ChangeUsername([FromBody] ChangeUsernameDto changeUsernameDto)
+    {
+        var token = _accountService.ChangeUsername(changeUsernameDto);
+
+        return Ok(token);
+    }
+
+    [HttpPatch("ChangePassword")]
+    public ActionResult ChangePassword([FromBody] ChangePasswordDto changePasswordDto)
+    {
+        _accountService.ChangePassword(changePasswordDto);
+
+        return Ok("Password successfully changed");
+    }
+
+    [HttpDelete("DeleteAccount")]
+    public ActionResult DeleteUser()
+    {
+        _accountService.DeleteAccount();
+
+        return NoContent();
+    }
 }

--- a/MoviesOnDemandBackend/Models/ChangeEmailDto.cs
+++ b/MoviesOnDemandBackend/Models/ChangeEmailDto.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesOnDemandBackend.Models;
+
+public class ChangeEmailDto
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; }
+}

--- a/MoviesOnDemandBackend/Models/ChangePasswordDto.cs
+++ b/MoviesOnDemandBackend/Models/ChangePasswordDto.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesOnDemandBackend.Models;
+
+public class ChangePasswordDto
+{
+    [Required]
+    public string Password { get; set; }
+    [Required]
+    [MinLength(6)]
+    public string NewPassword { get; set; }
+    [Required]
+    [MinLength(6)]
+    [Compare("NewPassword")]
+    public string ConfirmPassword { get; set; }
+}

--- a/MoviesOnDemandBackend/Models/ChangeUsernameDto.cs
+++ b/MoviesOnDemandBackend/Models/ChangeUsernameDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesOnDemandBackend.Models;
+
+public class ChangeUsernameDto
+{
+    [Required]
+    public string Username { get; set; }
+}

--- a/MoviesOnDemandBackend/MoviesOnDemandBackend.csproj
+++ b/MoviesOnDemandBackend/MoviesOnDemandBackend.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
       <Folder Include="Migrations" />
+      <Folder Include="Other" />
     </ItemGroup>
 
 </Project>

--- a/MoviesOnDemandBackend/Services/AccountService.cs
+++ b/MoviesOnDemandBackend/Services/AccountService.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using MoviesOnDemandBackend.Entities;
@@ -11,16 +13,29 @@ public interface IAccountService
 {
     UserDto GetCurrentUser();
     IEnumerable<MovieDto> GetUserFavoriteMovies();
+    string ChangeEmail(ChangeEmailDto changeEmailDto);
+    string ChangeUsername(ChangeUsernameDto changeUsernameDto);
+    void ChangePassword(ChangePasswordDto changePasswordDto);
+    void DeleteAccount();
+
 }
 
 public class AccountService : IAccountService
 {
+    private readonly IAuthenticationService _authenticationService;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IMapper _mapper;
     private readonly MoviesOnDemandDbContext _dbContext;
     
-    public AccountService(IHttpContextAccessor httpContextAccessor, IMapper mapper, MoviesOnDemandDbContext dbContext)
+    public AccountService
+    (
+        IAuthenticationService authenticationService, 
+        IHttpContextAccessor httpContextAccessor, 
+        IMapper mapper, 
+        MoviesOnDemandDbContext dbContext
+    )
     {
+        _authenticationService = authenticationService;
         _httpContextAccessor = httpContextAccessor;
         _mapper = mapper;
         _dbContext = dbContext;
@@ -75,5 +90,144 @@ public class AccountService : IAccountService
         }
         
         return movieDtos;
+    }
+
+    public string ChangeEmail(ChangeEmailDto changeEmailDto)
+    {
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new BadRequestException("Couldn't process request");
+        }
+
+        var email = _dbContext
+            .Users
+            .Select(u => u.Email)
+            .SingleOrDefault(u => u.Equals(changeEmailDto.Email));
+        
+        if (email is not null)
+        {
+            throw new BadRequestException("E-mail already in use");
+        }
+
+        var user = _dbContext
+            .Users
+            .SingleOrDefault(u =>
+                u.Id == Convert.ToInt32(_httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)));
+
+        if (user is null)
+        {
+            throw new NotFoundException("User not found");
+        }
+
+        user.Email = changeEmailDto.Email;
+        _dbContext.SaveChanges();
+
+        return _authenticationService.RefreshToken();
+    }
+
+    public string ChangeUsername(ChangeUsernameDto changeUsernameDto)
+    {
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new BadRequestException("Couldn't process request");
+        }
+
+        var username = _dbContext
+            .Users
+            .Select(u => u.Username)
+            .SingleOrDefault(u => u.Equals(changeUsernameDto.Username));
+
+        if (username is not null)
+        {
+            throw new BadRequestException("Username already in use");
+        }
+
+        var user = _dbContext
+            .Users
+            .SingleOrDefault(u =>
+                u.Id == Convert.ToInt32(_httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)));
+
+        if (user is null)
+        {
+            throw new NotFoundException("User not found");
+        }
+        
+        user.Username = changeUsernameDto.Username;
+        _dbContext.SaveChanges();
+        
+        return _authenticationService.RefreshToken();
+    }
+
+    public void ChangePassword(ChangePasswordDto changePasswordDto)
+    {
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new BadRequestException("Couldn't process request");
+        }
+
+        var user = _dbContext
+            .Users
+            .SingleOrDefault(u =>
+                u.Id == Convert.ToInt32(_httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)));
+        
+        if (user is null)
+        {
+            throw new NotFoundException("User not found");
+        }
+
+        if (!VerifyPasswordHash(changePasswordDto.Password, user.PasswordHash, user.PasswordSalt))
+        {
+            throw new BadRequestException("Wrong password");
+        }
+
+        if (VerifyPasswordHash(changePasswordDto.ConfirmPassword, user.PasswordHash, user.PasswordSalt))
+        {
+            throw new BadRequestException("You cannot set your current password as your new password");
+        }
+        
+        CreatePasswordHash(changePasswordDto.ConfirmPassword, out byte[] passwordHash, out byte[] passwordSalt);
+        user.PasswordHash = passwordHash;
+        user.PasswordSalt = passwordSalt;
+
+        _dbContext.SaveChanges();
+    }
+
+    public void DeleteAccount()
+    {
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new BadRequestException("Couldn't process request");
+        }
+
+        var user = _dbContext
+            .Users
+            .SingleOrDefault(u => 
+                u.Id == Convert.ToInt32(_httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)));
+
+        if (user is null)
+        {
+            throw new NotFoundException("User not found");
+        }
+
+        _dbContext.Users.Remove(user);
+        _dbContext.SaveChanges();
+    }
+
+    private void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt)
+    {
+        using (var hmac = new HMACSHA512())
+        {
+            passwordSalt = hmac.Key;
+            passwordHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
+        }
+    }
+    
+    private bool VerifyPasswordHash(string password, byte[] passwordHash, byte[] passwordSalt)
+    {
+        using (var hmac = new HMACSHA512(passwordSalt))
+        {
+            var computedHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
+            return computedHash.SequenceEqual(passwordHash);
+        }
     }
 }

--- a/MoviesOnDemandBackend/Services/RegistrationService.cs
+++ b/MoviesOnDemandBackend/Services/RegistrationService.cs
@@ -25,16 +25,22 @@ public class RegistrationService : IRegistrationService
 
     public UserDto Register(UserRegisterDto userRegisterDto)
     {
-        var dbUser = _dbContext.Users.SingleOrDefault(u => u.Email == userRegisterDto.Email);
+        var email = _dbContext
+            .Users
+            .Select(u => u.Email)
+            .SingleOrDefault(e => e.Equals(userRegisterDto.Email));
         
-        if (dbUser is not null)
+        if (email is not null)
         {
             throw new BadRequestException("User already exists");
         }
 
-        dbUser = _dbContext.Users.SingleOrDefault(u => u.Username == userRegisterDto.Username);
+        var username = _dbContext
+            .Users
+            .Select(u => u.Username)
+            .SingleOrDefault(u => u.Equals(userRegisterDto.Username));
 
-        if (dbUser is not null)
+        if (username is not null)
         {
             throw new BadRequestException("Username taken");
         }


### PR DESCRIPTION
[Patch] /Api/Account/V1/ChangeEmail, [Patch] /Api/Account/V1/ChangeUsername, [Patch] /Api/Account/V1/ChangePassword lets you respectively change your email address, username and password. Validates if email or username already exist, returns 200 ok with new JWT if everything goes well, validates if ConfirmPassword and NewPassword properties of ChangePasswordDto match, after that checks if ConfirmPassword and current password are not the same. [Delete] Api/Account/V1/DeleteAccount lets user delete their account, returns 204 no content. Registration Service now doesn't extract full user information when checking if email or username are already taken. Authentication Service now doesn't map User to UserDto before creating/refreshing JWT since it doesn't grant any benefits and just slows code