### PR TITLE
Adding, updating and deleting movies. Movie rating included. Route update. Movie entity update

### DIFF
--- a/MoviesOnDemandBackend/Controllers/MoviesController.cs
+++ b/MoviesOnDemandBackend/Controllers/MoviesController.cs
@@ -1,11 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using MoviesOnDemandBackend.Entities;
 using MoviesOnDemandBackend.Models;
 using MoviesOnDemandBackend.Services;
 
 namespace MoviesOnDemandBackend.Controllers;
 
 [ApiController]
-[Route("Api/[controller]")]
+[Authorize(Roles = "admin")]
+[Route("Api/[Controller]/V1")]
 public class MoviesController : ControllerBase
 {
     private readonly IMoviesService _moviesService;
@@ -15,19 +18,43 @@ public class MoviesController : ControllerBase
         _moviesService = moviesService;
     }
 
-    [HttpGet]
-    public ActionResult<List<MovieDto>> GetAllMovies()
+    [HttpGet, AllowAnonymous]
+    public ActionResult<IEnumerable<MovieDto>> GetAllMovies()
     {
         var movies = _moviesService.GetAllMovies();
 
         return Ok(movies);
     }
 
-    [HttpGet("{id}")]
+    [HttpGet("{id}"), AllowAnonymous]
     public ActionResult<MovieDto> GetMovieById([FromRoute]int id)
     {
         var movie = _moviesService.GetMovieById(id);
 
         return Ok(movie);
+    }
+
+    [HttpPost("AddMovie")]
+    public ActionResult<MovieDto> AddMovie([FromBody] AddMovieDto addMovieDto)
+    {
+        var movieDto = _moviesService.AddMovie(addMovieDto);
+
+        return Created($"/Api/Movies/V1/{movieDto.Id}", movieDto);
+    }
+
+    [HttpPatch("UpdateMovie/{id}")]
+    public ActionResult UpdateMovie([FromRoute] int id, [FromBody] UpdateMovieDto updateMovieDto)
+    {
+        _moviesService.UpdateMovie(id, updateMovieDto);
+
+        return Ok("Movie successfully updated");
+    }
+
+    [HttpDelete("DeleteMovie/{id}")]
+    public ActionResult DeleteMovie([FromRoute] int id)
+    {
+        _moviesService.DeleteMovie(id);
+
+        return NoContent();
     }
 }

--- a/MoviesOnDemandBackend/Entities/Configurations/MoviesConfiguration.cs
+++ b/MoviesOnDemandBackend/Entities/Configurations/MoviesConfiguration.cs
@@ -24,8 +24,7 @@ public class MoviesConfiguration : IEntityTypeConfiguration<Movie>
 
         builder
             .Property(m => m.Year)
-            .HasMaxLength(4)
-            .IsRequired();
+            .HasMaxLength(4);
 
         builder
             .HasData(

--- a/MoviesOnDemandBackend/Entities/Movie.cs
+++ b/MoviesOnDemandBackend/Entities/Movie.cs
@@ -5,7 +5,7 @@ public class Movie
     public int Id { get; set; }
     public string Title { get; set; }
     public string? Genre { get; set; }
-    public ushort Year { get; set; }
+    public ushort? Year { get; set; }
     
     public ICollection<User> Users { get; set; }
     public ICollection<Rating> Ratings { get; set; }

--- a/MoviesOnDemandBackend/Mapping/MovieMappingProfile.cs
+++ b/MoviesOnDemandBackend/Mapping/MovieMappingProfile.cs
@@ -9,5 +9,6 @@ public class MovieMappingProfile : Profile
     public MovieMappingProfile()
     {
         CreateMap<Movie, MovieDto>();
+        CreateMap<AddMovieDto, Movie>();
     }
 }

--- a/MoviesOnDemandBackend/Migrations/20230324091555_YearNullable.Designer.cs
+++ b/MoviesOnDemandBackend/Migrations/20230324091555_YearNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MoviesOnDemandBackend.Entities;
 
@@ -11,9 +12,11 @@ using MoviesOnDemandBackend.Entities;
 namespace MoviesOnDemandBackend.Migrations
 {
     [DbContext(typeof(MoviesOnDemandDbContext))]
-    partial class MoviesOnDemandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230324091555_YearNullable")]
+    partial class YearNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MoviesOnDemandBackend/Migrations/20230324091555_YearNullable.cs
+++ b/MoviesOnDemandBackend/Migrations/20230324091555_YearNullable.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoviesOnDemandBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class YearNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Year",
+                table: "Movies",
+                type: "int",
+                maxLength: 4,
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldMaxLength: 4);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "AccountCreated", "PasswordHash", "PasswordSalt" },
+                values: new object[] { new DateTime(2023, 3, 24, 0, 0, 0, 0, DateTimeKind.Local), new byte[] { 215, 179, 34, 141, 178, 133, 131, 240, 88, 150, 140, 207, 251, 154, 168, 245, 56, 15, 212, 54, 26, 61, 175, 198, 186, 108, 61, 239, 114, 211, 194, 85, 158, 30, 228, 36, 221, 70, 13, 31, 37, 7, 196, 18, 74, 1, 178, 251, 161, 15, 163, 161, 174, 174, 164, 182, 60, 231, 62, 44, 55, 206, 118, 170 }, new byte[] { 227, 204, 188, 76, 38, 32, 47, 224, 223, 15, 45, 186, 63, 131, 226, 95, 222, 242, 77, 133, 216, 181, 241, 171, 182, 230, 105, 120, 156, 75, 198, 81, 109, 119, 230, 202, 81, 45, 201, 207, 190, 228, 100, 41, 225, 249, 227, 204, 55, 52, 211, 124, 71, 226, 49, 155, 213, 50, 168, 27, 149, 78, 104, 129, 67, 181, 153, 146, 146, 189, 165, 120, 179, 41, 68, 175, 202, 51, 252, 94, 116, 162, 144, 251, 77, 239, 95, 106, 41, 154, 52, 217, 78, 50, 118, 107, 122, 17, 79, 9, 224, 58, 10, 77, 169, 253, 27, 41, 23, 186, 159, 32, 37, 179, 97, 78, 177, 29, 130, 196, 129, 88, 15, 4, 200, 78, 127, 104 } });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Year",
+                table: "Movies",
+                type: "int",
+                maxLength: 4,
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldMaxLength: 4,
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "AccountCreated", "PasswordHash", "PasswordSalt" },
+                values: new object[] { new DateTime(2023, 3, 16, 0, 0, 0, 0, DateTimeKind.Local), new byte[] { 209, 234, 193, 226, 75, 52, 114, 68, 13, 30, 65, 218, 211, 244, 196, 129, 123, 19, 37, 210, 113, 106, 181, 22, 43, 92, 167, 247, 168, 29, 35, 218, 167, 101, 16, 226, 27, 179, 28, 67, 201, 252, 132, 155, 176, 171, 163, 53, 193, 108, 14, 198, 221, 251, 87, 72, 143, 109, 79, 253, 179, 221, 6, 62 }, new byte[] { 150, 159, 126, 49, 132, 90, 146, 123, 187, 15, 98, 114, 170, 45, 92, 106, 84, 180, 224, 141, 106, 168, 104, 109, 217, 66, 22, 162, 3, 177, 90, 124, 43, 115, 79, 152, 84, 22, 45, 179, 99, 249, 96, 126, 19, 119, 249, 90, 131, 195, 202, 31, 26, 149, 230, 182, 158, 190, 53, 34, 71, 92, 67, 48, 234, 38, 65, 128, 185, 28, 103, 17, 214, 182, 28, 9, 237, 174, 64, 104, 139, 70, 108, 72, 136, 152, 16, 221, 163, 213, 148, 195, 23, 5, 40, 155, 144, 248, 2, 253, 227, 139, 68, 155, 231, 117, 117, 198, 174, 127, 244, 51, 251, 153, 151, 151, 72, 189, 144, 213, 18, 109, 220, 241, 118, 84, 5, 19 } });
+        }
+    }
+}

--- a/MoviesOnDemandBackend/Models/AddMovieDto.cs
+++ b/MoviesOnDemandBackend/Models/AddMovieDto.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesOnDemandBackend.Models;
+
+public class AddMovieDto
+{
+    [Required]
+    [MaxLength(100)]
+    public string Title { get; set; }
+    [MaxLength(50)]
+    public string? Genre { get; set; }
+    [Range(0, 9999)] 
+    public ushort? Year { get; set; } = null;
+}

--- a/MoviesOnDemandBackend/Models/MovieDto.cs
+++ b/MoviesOnDemandBackend/Models/MovieDto.cs
@@ -5,6 +5,6 @@ public class MovieDto
     public int Id { get; set; }
     public string Title { get; set; }
     public string? Genre { get; set; }
-    public string Year { get; set; }
+    public ushort? Year { get; set; }
     public decimal Rating { get; set; }
 }

--- a/MoviesOnDemandBackend/Models/UpdateMovieDto.cs
+++ b/MoviesOnDemandBackend/Models/UpdateMovieDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesOnDemandBackend.Models;
+
+public class UpdateMovieDto
+{
+    [MaxLength(100)]
+    public string? Title { get; set; }
+    [MaxLength(50)]
+    public string? Genre { get; set; }
+    [Range(0,9999)]
+    public ushort? Year { get; set; }
+}

--- a/MoviesOnDemandBackend/Services/MoviesService.cs
+++ b/MoviesOnDemandBackend/Services/MoviesService.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Microsoft.EntityFrameworkCore;
 using MoviesOnDemandBackend.Entities;
 using MoviesOnDemandBackend.Exceptions;
 using MoviesOnDemandBackend.Models;
@@ -7,8 +8,11 @@ namespace MoviesOnDemandBackend.Services;
 
 public interface IMoviesService
 {
-    List<MovieDto> GetAllMovies();
+    IEnumerable<MovieDto> GetAllMovies();
     MovieDto GetMovieById(int id);
+    MovieDto AddMovie(AddMovieDto addMovieDto);
+    void UpdateMovie(int id, UpdateMovieDto updateMovieDto);
+    void DeleteMovie(int id);
 }
 
 public class MoviesService : IMoviesService
@@ -22,24 +26,109 @@ public class MoviesService : IMoviesService
         _dbContext = dbContext;
     }
 
-    public List<MovieDto> GetAllMovies()
+    public IEnumerable<MovieDto> GetAllMovies()
     {
-        var movies = _dbContext.Movies.ToList();
+        var movies = _dbContext
+            .Movies
+            .Include(m => m.Ratings)
+            .ToList();
 
-        var movieDtos = _mapper.Map<List<Movie>, List<MovieDto>>(movies); 
+        var movieDtos = _mapper.Map<List<Movie>, List<MovieDto>>(movies);
+
+        for (var i = 0; i < movieDtos.Count; i++)
+        {
+            if (movies[i].Ratings.Count == 0)
+            {
+                continue;
+            }
+
+            movieDtos[i].Rating = decimal.Round(Convert.ToDecimal(movies[i].Ratings.Sum(r => r.Value)) 
+                                                / Convert.ToDecimal(movies[i].Ratings.Count), 1);
+        }
         
         return movieDtos;
     }
 
     public MovieDto GetMovieById(int id)
     {
-        var movie = _dbContext.Movies.FirstOrDefault(m => m.Id == id);
+        var movie = _dbContext
+            .Movies
+            .Include(m => m.Ratings)
+            .SingleOrDefault(m => m.Id == id);
 
         if (movie is null)
             throw new NotFoundException($"Movie of given id: {id} not found.");
 
         var movieDto = _mapper.Map<Movie, MovieDto>(movie); 
         
+        if (movie.Ratings.Count != 0)
+        {
+            movieDto.Rating = decimal.Round(Convert.ToDecimal(movie.Ratings.Sum(r => r.Value)) 
+                                                / Convert.ToDecimal(movie.Ratings.Count), 1);    
+        }
+
         return movieDto;
+    }
+    
+    public MovieDto AddMovie(AddMovieDto addMovieDto)
+    {
+        var dbMovie = _dbContext
+            .Movies
+            .SingleOrDefault(m => m.Title.Replace(" ", "").ToLower() 
+                                  == addMovieDto.Title.Replace(" ", "").ToLower());
+
+        if (dbMovie is not null)
+        {
+            throw new BadRequestException("Movie already exists");
+        }
+
+        var movie = _mapper.Map<AddMovieDto, Movie>(addMovieDto);
+
+        _dbContext.Movies.Add(movie);
+        _dbContext.SaveChanges();
+
+        var movieDto = _mapper.Map<Movie, MovieDto>(movie);
+        
+        return movieDto;
+    }
+
+    public void UpdateMovie(int id, UpdateMovieDto updateMovieDto)
+    {
+        var movie = _dbContext.Movies.SingleOrDefault(m => m.Id == id);
+
+        if (movie is null)
+        {
+            throw new NotFoundException("Movie not found");
+        }
+
+        if (updateMovieDto.Title is not null)
+        {
+            movie.Title = updateMovieDto.Title;
+        }
+
+        if (updateMovieDto.Genre is not null)
+        {
+            movie.Genre = updateMovieDto.Genre;
+        }
+
+        if (updateMovieDto.Year is not null)
+        {
+            movie.Year = updateMovieDto.Year;
+        }
+
+        _dbContext.SaveChanges();
+    }
+
+    public void DeleteMovie(int id)
+    {
+        var movie = _dbContext.Movies.SingleOrDefault(m => m.Id == id);
+
+        if (movie is null)
+        {
+            throw new NotFoundException("Movie not found");
+        }
+
+        _dbContext.Movies.Remove(movie);
+        _dbContext.SaveChanges();
     }
 }


### PR DESCRIPTION
[Post] /Api/Movies/V1/AddMovie and [Patch] /Api/Movies/V1/UpdateMovie/{movieId} lets admin account, respectively, add and update movie. AddMovie requiries Title property, AddMovie and UpdateMovie requiries Title property to have a max length of 100, Genre to have a max length of 50 and Year to be in range 0-9999. AddMovie takes AddMovieDto as an argument and maps it to Movie entity, returns 201 created with route to movie and newly created movie object, UpdateMovie takes movie Id and UpdateMovieDto as arguments, returns 200 ok when movie is updated. [Delete] Api/Movies/V1/DeleteMovie/{movieid} lets admin delete the movie, returns 204 no content. [Get] /Api/Movies/V1 and /Api/Movies/V1/{movieId} now include ratings for returned movies. Route changed from /Api/Movies to /Api/Movies/V1. Year property of Movie entity now can be nullable